### PR TITLE
Remove codecov token as it's not needed for public repos

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,6 @@ jobs:
         env:
           SPARK_VERSION: ${{ matrix.SPARK_VERSION }}
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           flags: ${{ matrix.PROFILE }}
           env_vars: SPARK_VERSION
           fail_ci_if_error: true


### PR DESCRIPTION
Signed-off-by: Florian Froese <ffr@zurich.ibm.com>